### PR TITLE
Buffs space heaters from Trillbyspaceclone#12241

### DIFF
--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -115,8 +115,8 @@
 		return PROCESS_KILL
 
 /obj/machinery/space_heater/RefreshParts()
-	var/laser = 0
-	var/cap = 0
+	var/laser = 2
+	var/cap = 1
 	for(var/obj/item/stock_parts/micro_laser/M in component_parts)
 		laser += M.rating
 	for(var/obj/item/stock_parts/capacitor/M in component_parts)
@@ -161,6 +161,8 @@
 		update_icon()
 		if(panel_open)
 			interact(user)
+	else if(default_unfasten_wrench(user, I))
+		return
 	else if(default_deconstruction_crowbar(I))
 		return
 	else


### PR DESCRIPTION
##About The Pull Request
space heaters can now be wrenched and unwrenched to remove bolts
space heaters now have 300% more laser powering and 200% more capacitor power

##Why It's Good For The Game
These things are worthless at dealing with most things above just 120c or below -30C
taking a long time and generaly only fixing slowly the 4~ tile area its around this fixes that
QoL to not have to make and un make a newly built space heater when you have to move it to cool the room

##Changelog
🆑
add: Space heaters can now be wrenched and unwrenched
balance: Space heaters drain less and can reach even hotter/colder temps faster!
/🆑