### PR TITLE
Replaces decal painter menu with a radial menu

### DIFF
--- a/code/game/objects/items/airlock_painter.dm
+++ b/code/game/objects/items/airlock_painter.dm
@@ -129,7 +129,7 @@
 
 /obj/item/airlock_painter/decal
 	name = "decal painter"
-	desc = "An airlock painter, reprogramed to use a different style of paint in order to apply decals for floor tiles as well, in addition to repainting doors. Decals break when the floor tiles are removed. Alt-Click or Ctrl-Click to change design."
+	desc = "An airlock painter, reprogramed to use a different style of paint in order to apply decals for floor tiles as well, in addition to repainting doors. Decals break when the floor tiles are removed. Alt-Click to change design."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "decal_sprayer"
 	item_state = "decalsprayer"

--- a/code/game/objects/items/airlock_painter.dm
+++ b/code/game/objects/items/airlock_painter.dm
@@ -166,7 +166,7 @@
 		return
 	. = ..()
 
-/obj/item/airlock_painter/decal/AltClick(mob/user)
+/obj/item/airlock_painter/decal/AltClick(mob/user) //sandstorm change - everything that makes this work is on same path to this but on sandcode
 	. = ..()
 	var/decal_category = list(
 		"Decal" = image(icon = 'icons/turf/decals.dmi', icon_state = "[stored_decal]", dir = stored_dir),
@@ -184,10 +184,6 @@
 		if("Dir")
 			choose_dir(user)
 
-/obj/item/airlock_painter/decal/CtrlClick(mob/user)
-	. = ..()
-	ui_interact(user)
-
 /obj/item/airlock_painter/decal/Initialize()
 	. = ..()
 	ink = new /obj/item/toner/large(src)
@@ -198,53 +194,6 @@
 		yellow_fix = "_"
 	stored_decal_total = "[stored_decal][yellow_fix][stored_color]"
 	return
-
-/obj/item/airlock_painter/decal/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = 0, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
-	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
-	if(!ui)
-		ui = new(user, src, ui_key, "decal_painter", name, 500, 400, master_ui, state)
-		ui.open()
-
-/obj/item/airlock_painter/decal/ui_data(mob/user)
-	var/list/data = list()
-	data["decal_direction"] = stored_dir
-	data["decal_color"] = stored_color
-	data["decal_style"] = stored_decal
-	data["decal_list"] = list()
-	data["color_list"] = list()
-	data["dir_list"] = list()
-
-	for(var/i in decal_list)
-		data["decal_list"] += list(list(
-			"name" = i[1],
-			"decal" = i[2]
-		))
-	for(var/j in color_list)
-		data["color_list"] += list(list(
-			"colors" = j
-		))
-	for(var/k in dir_list)
-		data["dir_list"] += list(list(
-			"dirs" = k
-		))
-	return data
-
-/obj/item/airlock_painter/decal/ui_act(action,list/params)
-	if(..())
-		return
-	switch(action)
-		//Lists of decals and designs
-		if("select decal")
-			var/selected_decal = params["decals"]
-			stored_decal = selected_decal
-		if("select color")
-			var/selected_color = params["colors"]
-			stored_color = selected_color
-		if("selected direction")
-			var/selected_direction = text2num(params["dirs"])
-			stored_dir = selected_direction
-	update_decal_path()
-	. = TRUE
 
 /obj/item/airlock_painter/decal/debug
 	name = "extreme decal painter"

--- a/code/game/objects/items/airlock_painter.dm
+++ b/code/game/objects/items/airlock_painter.dm
@@ -129,7 +129,7 @@
 
 /obj/item/airlock_painter/decal
 	name = "decal painter"
-	desc = "An airlock painter, reprogramed to use a different style of paint in order to apply decals for floor tiles as well, in addition to repainting doors. Decals break when the floor tiles are removed. Alt-Click to change design."
+	desc = "An airlock painter, reprogramed to use a different style of paint in order to apply decals for floor tiles as well, in addition to repainting doors. Decals break when the floor tiles are removed. Alt-Click or Ctrl-Click to change design."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "decal_sprayer"
 	item_state = "decalsprayer"
@@ -140,7 +140,8 @@
 	var/stored_decal_total = "warningline"
 	var/color_list = list("","red","white")
 	var/dir_list = list(1,2,4,8)
-	var/decal_list = list(list("Warning Line","warningline"),
+	var/decal_list = list(
+			list("Warning Line","warningline"),
 			list("Warning Line Corner","warninglinecorner"),
 			list("Caution Label","caution"),
 			list("Directional Arrows","arrows"),
@@ -166,6 +167,24 @@
 	. = ..()
 
 /obj/item/airlock_painter/decal/AltClick(mob/user)
+	. = ..()
+	var/decal_category = list(
+		"Decal" = image(icon = 'icons/turf/decals.dmi', icon_state = "[stored_decal]", dir = stored_dir),
+		"Color" = image(icon = 'icons/obj/crayons.dmi', icon_state = "crayonred"),
+		"Dir" = image(icon = 'icons/obj/device.dmi', icon_state = "pinonfar", dir = stored_dir)
+	)
+	var/cat_chosen = show_radial_menu(user,src,decal_category, custom_check = CALLBACK(src,.proc/check_menu,user), require_near = TRUE, tooltips = TRUE)
+	if(!check_menu(user))
+		return
+	switch(cat_chosen)
+		if("Decal")
+			choose_decal(user)
+		if("Color")
+			choose_color(user)
+		if("Dir")
+			choose_dir(user)
+
+/obj/item/airlock_painter/decal/CtrlClick(mob/user)
 	. = ..()
 	ui_interact(user)
 

--- a/sandcode/code/game/objects/items/airlock_painter.dm
+++ b/sandcode/code/game/objects/items/airlock_painter.dm
@@ -1,0 +1,142 @@
+
+/obj/item/airlock_painter/decal/proc/check_menu(mob/living/user)
+	if(!istype(user))
+		return FALSE
+	if(user.incapacitated() || !user.Adjacent(src))
+		return FALSE
+	return TRUE
+
+/obj/item/airlock_painter/decal/proc/choose_decal(user)
+	var/decal_list_img = list(
+		"Warning Line" = image(icon = 'icons/turf/decals.dmi', icon_state = "warningline", dir = stored_dir),
+		"Warning Line Corner" = image(icon = 'icons/turf/decals.dmi', icon_state = "warninglinecorner", dir = stored_dir),
+		"Caution Label" = image(icon = 'icons/turf/decals.dmi', icon_state = "caution", dir = stored_dir),
+		"Directional Arrows" = image(icon = 'icons/turf/decals.dmi', icon_state = "arrows", dir = stored_dir),
+		"Stand Clear Label" = image(icon = 'icons/turf/decals.dmi', icon_state = "stand_clear", dir = stored_dir),
+		"Box" = image(icon = 'icons/turf/decals.dmi', icon_state = "box", dir = stored_dir),
+		"Box Corner" = image(icon = 'icons/turf/decals.dmi', icon_state = "box_corners", dir = stored_dir),
+		"Delivery Marker" = image(icon = 'icons/turf/decals.dmi', icon_state = "delivery", dir = stored_dir),
+		"Warning Box" = image(icon = 'icons/turf/decals.dmi', icon_state = "warn_full", dir = stored_dir)
+	)
+	var/choice = show_radial_menu(user,src,decal_list_img, custom_check = CALLBACK(src,.proc/check_menu,user), require_near = TRUE, tooltips = TRUE)
+	if(!check_menu(user))
+		return
+	switch(choice)
+		if("Warning Line")
+			var/picked_decal = decal_list[1]
+			stored_decal = picked_decal[2]
+			playsound(src, 'sound/effects/pop.ogg', 50, 0)
+			to_chat(user, "<span class='notice'>You change [src] decal to '[choice]'.</span>")
+			update_decal_path()
+		if("Warning Line Corner")
+			var/picked_decal = decal_list[2]
+			stored_decal = picked_decal[2]
+			playsound(src, 'sound/effects/pop.ogg', 50, 0)
+			to_chat(user, "<span class='notice'>You change [src] decal to '[choice]'.</span>")
+			update_decal_path()
+		if("Caution Label")
+			var/picked_decal = decal_list[3]
+			stored_decal = picked_decal[2]
+			playsound(src, 'sound/effects/pop.ogg', 50, 0)
+			to_chat(user, "<span class='notice'>You change [src] decal to '[choice]'.</span>")
+			update_decal_path()
+		if("Directional Arrows")
+			var/picked_decal = decal_list[4]
+			stored_decal = picked_decal[2]
+			playsound(src, 'sound/effects/pop.ogg', 50, 0)
+			to_chat(user, "<span class='notice'>You change [src] decal to '[choice]'.</span>")
+			update_decal_path()
+		if("Stand Clear Label")
+			var/picked_decal = decal_list[5]
+			stored_decal = picked_decal[2]
+			playsound(src, 'sound/effects/pop.ogg', 50, 0)
+			to_chat(user, "<span class='notice'>You change [src] decal to '[choice]'.</span>")
+			update_decal_path()
+		if("Box")
+			var/picked_decal = decal_list[6]
+			stored_decal = picked_decal[2]
+			playsound(src, 'sound/effects/pop.ogg', 50, 0)
+			to_chat(user, "<span class='notice'>You change [src] decal to '[choice]'.</span>")
+			update_decal_path()
+		if("Box Corner")
+			var/picked_decal = decal_list[7]
+			stored_decal = picked_decal[2]
+			playsound(src, 'sound/effects/pop.ogg', 50, 0)
+			to_chat(user, "<span class='notice'>You change [src] decal to '[choice]'.</span>")
+			update_decal_path()
+		if("Delivery Marker")
+			var/picked_decal = decal_list[8]
+			stored_decal = picked_decal[2]
+			playsound(src, 'sound/effects/pop.ogg', 50, 0)
+			to_chat(user, "<span class='notice'>You change [src] decal to '[choice]'.</span>")
+			update_decal_path()
+		if("Warning Box")
+			var/picked_decal = decal_list[9]
+			stored_decal = picked_decal[2]
+			playsound(src, 'sound/effects/pop.ogg', 50, 0)
+			to_chat(user, "<span class='notice'>You change [src] decal to '[choice]'.</span>")
+			update_decal_path()
+		else
+			to_chat(user, "<span class='notice'>You decided not to change the decal.")
+
+/obj/item/airlock_painter/decal/proc/choose_color(user)
+	var/choose_color = list(
+		"Disable" = image(icon = 'icons/turf/decals.dmi', icon_state = "[stored_decal]", dir = stored_dir),
+		"Red" = image(icon = 'icons/obj/crayons.dmi', icon_state = "crayonred"),
+		"White" = image(icon = 'icons/obj/crayons.dmi', icon_state = "crayonwhite")
+	)
+	var/choice = show_radial_menu(user,src,choose_color, custom_check = CALLBACK(src,.proc/check_menu,user), require_near = TRUE, tooltips = TRUE)
+	if(!check_menu(user))
+		return
+	switch(choice)
+		if("Disable")
+			stored_color = color_list[1]
+			playsound(src, 'sound/effects/pop.ogg', 50, 0)
+			to_chat(user, "<span class='notice'>You disable [src]'s painter.</span>")
+			update_decal_path()
+		if("Red")
+			stored_color = color_list[2]
+			playsound(src, 'sound/effects/pop.ogg', 50, 0)
+			to_chat(user, "<span class='notice'>You change [src] color to '[choice]'.</span>")
+			update_decal_path()
+		if("White")
+			stored_color = color_list[3]
+			playsound(src, 'sound/effects/pop.ogg', 50, 0)
+			to_chat(user, "<span class='notice'>You change [src] color to '[choice]'.</span>")
+			update_decal_path()
+		else
+			to_chat(user, "<span class='notice'>You decided not to change the color.</span>")
+
+/obj/item/airlock_painter/decal/proc/choose_dir(user)
+	var/choose_dir = list(
+		"North" = image(icon = 'icons/turf/decals.dmi', icon_state = "[stored_decal]", dir = 1),
+		"East" = image(icon = 'icons/turf/decals.dmi', icon_state = "[stored_decal]", dir = 4),
+		"South" = image(icon = 'icons/turf/decals.dmi', icon_state = "[stored_decal]", dir = 2),
+		"West"  = image(icon = 'icons/turf/decals.dmi', icon_state = "[stored_decal]", dir = 8)
+	)
+	var/choice =  show_radial_menu(user,src,choose_dir, custom_check = CALLBACK(src,.proc/check_menu,user), require_near = TRUE, tooltips = TRUE)
+	if(!check_menu(user))
+		return
+	switch(choice)
+		if("North")
+			stored_dir = dir_list[1]
+			playsound(src, 'sound/effects/pop.ogg', 50, 0)
+			to_chat(user, "<span class='notice'>You change [src] direction to '[choice]'.</span>")
+			update_decal_path()
+		if("South")
+			stored_dir = dir_list[2]
+			playsound(src, 'sound/effects/pop.ogg', 50, 0)
+			to_chat(user, "<span class='notice'>You change [src] direction to '[choice]'.</span>")
+			update_decal_path()
+		if("East")
+			stored_dir = dir_list[3]
+			playsound(src, 'sound/effects/pop.ogg', 50, 0)
+			to_chat(user, "<span class='notice'>You change [src] direction to '[choice]'.</span>")
+			update_decal_path()
+		if("West")
+			stored_dir = dir_list[4]
+			playsound(src, 'sound/effects/pop.ogg', 50, 0)
+			to_chat(user, "<span class='notice'>You change [src] direction to '[choice]'.</span>")
+			update_decal_path()
+		else
+			to_chat(user, "<span class='notice'>You decided not to change the direction.</span>")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3502,6 +3502,7 @@
 #include "sandcode\code\game\machinery\pipe\construction.dm"
 #include "sandcode\code\game\mecha\mech_fabricator.dm"
 #include "sandcode\code\game\objects\effects\contraband.dm"
+#include "sandcode\code\game\objects\items\airlock_painter.dm"
 #include "sandcode\code\game\objects\items\BSRPD.dm"
 #include "sandcode\code\game\objects\items\cards_ids.dm"
 #include "sandcode\code\game\objects\items\circuitboards\computer_circuitboards.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It's a radial menu for decal painter, doesn't lose any functionality, except for removing the old menu.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Preview? and the radial menu is cool.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added the radial menu.
del: Removes the old ui for radial menu, and most of the things that make it work.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
