### PR TITLE
Breaks lines... with a crowbar

### DIFF
--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -15,8 +15,11 @@ SUBSYSTEM_DEF(statpanels)
 			"Map: [SSmapping.config?.map_name || "Loading..."]",
 			cached ? "Next Map: [cached.map_name]" : null,
 			"Round ID: [GLOB.round_id ? GLOB.round_id : "NULL"]",
-			"[SStime_track.stat_time_text]",
-			"Station Time: [STATION_TIME_TIMESTAMP("hh:mm:ss", world.time)]",
+			//"[SStime_track.stat_time_text]",
+			"[SStime_track.server_time_text]",
+			"[SStime_track.round_time_text]",
+			"[SStime_track.station_time_text]",
+			//"Station Time: [STATION_TIME_TIMESTAMP("hh:mm:ss", world.time)]",
 			"Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)"
 		)
 

--- a/code/controllers/subsystem/time_track.dm
+++ b/code/controllers/subsystem/time_track.dm
@@ -22,8 +22,18 @@ SUBSYSTEM_DEF(time_track)
 	var/stat_time_text
 	var/time_dilation_text
 
+	//sandstorm stuff, meant to separate lines on the status display.
+	var/server_time_text
+	var/round_time_text
+	var/station_time_text
+
 /datum/controller/subsystem/time_track/fire()
 	stat_time_text = "Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]\n\nRound Time: [DisplayTimeText(world.time - SSticker.round_start_time, 1)] \n\nStation Time: [STATION_TIME_TIMESTAMP("hh:mm:ss", world.time)]\n\n[time_dilation_text]"
+
+	//sandstorm stuff, meant to separate lines on the status display.
+	server_time_text = "Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]"
+	round_time_text = "Round Time: [DisplayTimeText(world.time - SSticker.round_start_time, 1)]"
+	station_time_text = "Station Time: [STATION_TIME_TIMESTAMP("hh:mm:ss", world.time)]"
 
 	if(++last_measurement == measurement_delay)
 		last_measurement = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Line breaking.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
`"Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]\n\nRound Time: [DisplayTimeText(world.time - SSticker.round_start_time, 1)] \n\nStation Time: [STATION_TIME_TIMESTAMP("hh:mm:ss", world.time)]\n\n[time_dilation_text]"`, despite the "\n"s will be displayed in a single line (also repeats some information that's already on the stat panel), this solves it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Time info on the stat panel is no longer messy.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
